### PR TITLE
Fix: 'FailInfo' is not defined and type 'EventCallable<void>' is not assignable to type 'EventCallable<FailInfo<T>>'

### DIFF
--- a/.changeset/ninety-pillows-smell.md
+++ b/.changeset/ninety-pillows-smell.md
@@ -1,0 +1,5 @@
+---
+"@farfetched/core": patch
+---
+
+Support for importing the FailInfo type has been added, and the type for the otherwise field in the retry configuration object has been extended (enabling the use of an event of type EventCallable<void>).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export { createHeadlessMutation } from './mutation/create_headless_mutation';
 export { createJsonMutation } from './mutation/create_json_mutation';
 
 // Retry public API
+export { type FailInfo } from './retry/retry';
 export { retry } from './retry/retry';
 export { exponentialDelay, linearDelay } from './retry/delay';
 

--- a/packages/core/src/retry/retry.ts
+++ b/packages/core/src/retry/retry.ts
@@ -31,7 +31,7 @@ import {
 } from '../remote_operation/type';
 import { type RetryMeta } from './type';
 
-type FailInfo<Q extends RemoteOperation<any, any, any, any>> = {
+export type FailInfo<Q extends RemoteOperation<any, any, any, any>> = {
   params: RemoteOperationParams<Q>;
   error: RemoteOperationError<Q>;
   meta: ExecutionMeta;
@@ -51,7 +51,7 @@ type RetryConfig<
     RemoteOperationParams<Q>,
     MapParamsSource
   >;
-  otherwise?: EventCallable<FailInfo<Q>>;
+  otherwise?: EventCallable<FailInfo<Q> | void>;
   supressIntermediateErrors?: boolean;
 };
 


### PR DESCRIPTION
Не всегда необходимо передавать информацию об ошибке в событие otherwise. Эти изменения не предотвращают передачу информации, но, по крайней мере, TypeScript перестанет выдавать ошибки. Экспорт FailInfo необходим, если нужно указать тип информации об ошибке в generic параметре у createEvent<FailInfo<T>>. На данный момент приходится использовать следующий подход:
```
type RemoteOperation = Mutation<any, any, any> | Query<any, any, any, any>;
type RetryConfig<T extends RemoteOperation> = Parameters<typeof retry<T>>['1'];
type Otherwise<T extends RemoteOperation> = Exclude<RetryConfig<T>['otherwise'], undefined>;
type FailInfo<T extends RemoteOperation> = Exclude<Parameters<Otherwise<T>>['0'], undefined>;

export const sessionSignOut: EventCallable<FailInfo<typeof sessionRefreshMut>> =
  createEvent<FailInfo<typeof sessionRefreshMut>>();
```