### PR TITLE
Add support for zod v4 and zod v4-mini

### DIFF
--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -7,12 +7,12 @@
   "license": "MIT",
   "repository": "https://github.com/igorkamyshev/farfetched",
   "devDependencies": {
-    "zod": "^3.19",
-    "@farfetched/core": "workspace:*"
+    "@farfetched/core": "workspace:*",
+    "zod": "^3.25.0"
   },
   "peerDependencies": {
-    "zod": "^3.19",
-    "@farfetched/core": "workspace:*"
+    "@farfetched/core": "workspace:*",
+    "zod": "^3.25.0"
   },
   "scripts": {
     "test:run": "vitest run --typecheck",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -12,7 +12,7 @@
   },
   "peerDependencies": {
     "@farfetched/core": "workspace:*",
-    "zod": "^3.25.0"
+    "zod": "^3.25.0 || ^4.0.0"
   },
   "scripts": {
     "test:run": "vitest run --typecheck",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/igorkamyshev/farfetched",
   "devDependencies": {
     "@farfetched/core": "workspace:*",
-    "zod": "^3.25.0"
+    "zod": "^3.25.67"
   },
   "peerDependencies": {
     "@farfetched/core": "workspace:*",

--- a/packages/zod/src/__tests__/contract.test-d.ts
+++ b/packages/zod/src/__tests__/contract.test-d.ts
@@ -1,11 +1,11 @@
 import { describe, test, expectTypeOf } from 'vitest';
-import { z as zod } from 'zod';
+import { z as zodV3 } from 'zod/v3';
 
 import { zodContract } from '../zod_contract';
 
-describe('zodContract', () => {
+describe('zodContract (zod v3)', () => {
   test('string', () => {
-    const stringContract = zodContract(zod.string());
+    const stringContract = zodContract(zodV3.string());
 
     const smth: unknown = null;
 
@@ -17,14 +17,14 @@ describe('zodContract', () => {
 
   test('complex object', () => {
     const complexContract = zodContract(
-      zod.tuple([
-        zod.object({
-          x: zod.number(),
-          y: zod.literal(false),
-          k: zod.set(zod.string()),
+      zodV3.tuple([
+        zodV3.object({
+          x: zodV3.number(),
+          y: zodV3.literal(false),
+          k: zodV3.set(zodV3.string()),
         }),
-        zod.literal('literal'),
-        zod.literal(42),
+        zodV3.literal('literal'),
+        zodV3.literal(42),
       ])
     );
 
@@ -60,15 +60,15 @@ describe('zodContract', () => {
   });
 
   test('branded type', () => {
-    const BrandedContainer = zod.object({
-      branded: zod.string().brand<'Branded'>(),
+    const BrandedContainer = zodV3.object({
+      branded: zodV3.string().brand<'Branded'>(),
     });
     const brandedContract = zodContract(BrandedContainer);
 
     const smth: unknown = { branded: 'branded' };
 
     if (brandedContract.isData(smth)) {
-      expectTypeOf(smth).toEqualTypeOf<zod.infer<typeof BrandedContainer>>();
+      expectTypeOf(smth).toEqualTypeOf<zodV3.infer<typeof BrandedContainer>>();
     }
   });
 });

--- a/packages/zod/src/__tests__/contract.test-d.ts
+++ b/packages/zod/src/__tests__/contract.test-d.ts
@@ -1,6 +1,7 @@
 import { describe, test, expectTypeOf } from 'vitest';
 import { z as zodV3 } from 'zod/v3';
 import { z as zodV4 } from 'zod/v4';
+import { z as zodV4mini } from 'zod/v4-mini';
 
 import { zodContract } from '../zod_contract';
 
@@ -140,6 +141,76 @@ describe('zodContract (zod v4)', () => {
 
     if (brandedContract.isData(smth)) {
       expectTypeOf(smth).toEqualTypeOf<zodV4.infer<typeof BrandedContainer>>();
+    }
+  });
+});
+
+describe('zodContract (zod v4-mini)', () => {
+  test('string', () => {
+    const stringContract = zodContract(zodV4mini.string());
+
+    const smth: unknown = null;
+
+    if (stringContract.isData(smth)) {
+      expectTypeOf(smth).toEqualTypeOf<string>();
+      expectTypeOf(smth).not.toEqualTypeOf<number>();
+    }
+  });
+
+  test('complex object', () => {
+    const complexContract = zodContract(
+      zodV4mini.tuple([
+        zodV4mini.object({
+          x: zodV4mini.number(),
+          y: zodV4mini.literal(false),
+          k: zodV4mini.set(zodV4mini.string()),
+        }),
+        zodV4mini.literal('literal'),
+        zodV4mini.literal(42),
+      ])
+    );
+
+    const smth: unknown = null;
+
+    if (complexContract.isData(smth)) {
+      expectTypeOf(smth).toEqualTypeOf<
+        [
+          {
+            x: number;
+            y: false;
+            k: Set<string>;
+          },
+          'literal',
+          42,
+        ]
+      >();
+
+      expectTypeOf(smth).not.toEqualTypeOf<number>();
+
+      expectTypeOf(smth).not.toEqualTypeOf<
+        [
+          {
+            x: string;
+            y: false;
+            k: Set<string>;
+          },
+          'literal',
+          42,
+        ]
+      >();
+    }
+  });
+
+  test('branded type', () => {
+    const BrandedContainer = zodV4mini.object({
+      branded: zodV4mini.string().brand<'Branded'>(),
+    });
+    const brandedContract = zodContract(BrandedContainer);
+
+    const smth: unknown = { branded: 'branded' };
+
+    if (brandedContract.isData(smth)) {
+      expectTypeOf(smth).toEqualTypeOf<zodV4mini.infer<typeof BrandedContainer>>();
     }
   });
 });

--- a/packages/zod/src/__tests__/contract.test-d.ts
+++ b/packages/zod/src/__tests__/contract.test-d.ts
@@ -210,7 +210,9 @@ describe('zodContract (zod v4-mini)', () => {
     const smth: unknown = { branded: 'branded' };
 
     if (brandedContract.isData(smth)) {
-      expectTypeOf(smth).toEqualTypeOf<zodV4mini.infer<typeof BrandedContainer>>();
+      expectTypeOf(smth).toEqualTypeOf<
+        zodV4mini.infer<typeof BrandedContainer>
+      >();
     }
   });
 });

--- a/packages/zod/src/__tests__/contract.test-d.ts
+++ b/packages/zod/src/__tests__/contract.test-d.ts
@@ -1,5 +1,6 @@
 import { describe, test, expectTypeOf } from 'vitest';
 import { z as zodV3 } from 'zod/v3';
+import { z as zodV4 } from 'zod/v4';
 
 import { zodContract } from '../zod_contract';
 
@@ -69,6 +70,76 @@ describe('zodContract (zod v3)', () => {
 
     if (brandedContract.isData(smth)) {
       expectTypeOf(smth).toEqualTypeOf<zodV3.infer<typeof BrandedContainer>>();
+    }
+  });
+});
+
+describe('zodContract (zod v4)', () => {
+  test('string', () => {
+    const stringContract = zodContract(zodV4.string());
+
+    const smth: unknown = null;
+
+    if (stringContract.isData(smth)) {
+      expectTypeOf(smth).toEqualTypeOf<string>();
+      expectTypeOf(smth).not.toEqualTypeOf<number>();
+    }
+  });
+
+  test('complex object', () => {
+    const complexContract = zodContract(
+      zodV4.tuple([
+        zodV4.object({
+          x: zodV4.number(),
+          y: zodV4.literal(false),
+          k: zodV4.set(zodV4.string()),
+        }),
+        zodV4.literal('literal'),
+        zodV4.literal(42),
+      ])
+    );
+
+    const smth: unknown = null;
+
+    if (complexContract.isData(smth)) {
+      expectTypeOf(smth).toEqualTypeOf<
+        [
+          {
+            x: number;
+            y: false;
+            k: Set<string>;
+          },
+          'literal',
+          42,
+        ]
+      >();
+
+      expectTypeOf(smth).not.toEqualTypeOf<number>();
+
+      expectTypeOf(smth).not.toEqualTypeOf<
+        [
+          {
+            x: string;
+            y: false;
+            k: Set<string>;
+          },
+          'literal',
+          42,
+        ]
+      >();
+    }
+  });
+
+  test('branded type', () => {
+    const BrandedContainer = zodV4.object({
+      branded: zodV4.string().brand<'Branded'>(),
+    });
+    const brandedContract = zodContract(BrandedContainer);
+
+    const smth: unknown = { branded: 'branded' };
+
+    if (brandedContract.isData(smth)) {
+      expectTypeOf(smth).toEqualTypeOf<zodV4.infer<typeof BrandedContainer>>();
     }
   });
 });

--- a/packages/zod/src/__tests__/contract.test.ts
+++ b/packages/zod/src/__tests__/contract.test.ts
@@ -1,4 +1,5 @@
 import { z as zod_v3 } from 'zod/v3';
+import { z as zod_v4 } from 'zod/v4';
 import { describe, test, expect } from 'vitest';
 
 import { zodContract } from '../zod_contract';
@@ -117,6 +118,125 @@ describe('zod/zodContract short (zod v3)', () => {
         "Expected number, received string, path: x",
         "Expected string, received number, path: y.z",
         "Expected boolean, received map, path: y.k.j",
+      ]
+    `);
+  });
+});
+
+describe('zod/zodContract short (zod v4)', () => {
+  const zod = zod_v4;
+
+  test('interprets invalid response as error', () => {
+    const contract = zodContract(zod.string());
+
+    expect(contract.getErrorMessages(2)).toMatchInlineSnapshot(`
+      [
+        "Invalid input: expected string, received number",
+      ]
+    `);
+  });
+
+  test('passes valid data', () => {
+    const contract = zodContract(zod.string());
+
+    expect(contract.getErrorMessages('foo')).toEqual([]);
+  });
+
+  test('isData passes for valid data', () => {
+    const contract = zodContract(
+      zod.object({
+        x: zod.number(),
+        y: zod.string(),
+      })
+    );
+
+    expect(
+      contract.isData({
+        x: 42,
+        y: 'answer',
+      })
+    ).toEqual(true);
+  });
+
+  test('isData does not pass for invalid data', () => {
+    const contract = zodContract(
+      zod.object({
+        x: zod.number(),
+        y: zod.string(),
+      })
+    );
+
+    expect(
+      contract.isData({
+        42: 'x',
+        answer: 'y',
+      })
+    ).toEqual(false);
+  });
+
+  test('interprets complex invalid response as error', () => {
+    const contract = zodContract(
+      zod.tuple([
+        zod.object({
+          x: zod.number(),
+          y: zod.literal(true),
+          k: zod
+            .set(zod.string())
+            .nonempty('Invalid input: expected set of strings'),
+        }),
+        zod.literal('Uhm?'),
+        zod.literal(42),
+      ])
+    );
+
+    expect(
+      contract.getErrorMessages([
+        {
+          x: 456,
+          y: false,
+          k: new Set(),
+        },
+        'Answer is:',
+        '42',
+      ])
+    ).toMatchInlineSnapshot(`
+      [
+        "Invalid input: expected true, path: 0.y",
+        "Invalid input: expected set of strings, path: 0.k",
+        "Invalid input: expected "Uhm?", path: 1",
+        "Invalid input: expected 42, path: 2",
+      ]
+    `);
+  });
+
+  test('path from original zod error included in final message', () => {
+    const contract = zodContract(
+      zod.object({
+        x: zod.number(),
+        y: zod.object({
+          z: zod.string(),
+          k: zod.object({
+            j: zod.boolean(),
+          }),
+        }),
+      })
+    );
+
+    expect(
+      contract.getErrorMessages({
+        x: '42',
+        y: {
+          z: 123,
+          k: {
+            j: new Map(),
+          },
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      [
+        "Invalid input: expected number, received string, path: x",
+        "Invalid input: expected string, received number, path: y.z",
+        "Invalid input: expected boolean, received Map, path: y.k.j",
       ]
     `);
   });

--- a/packages/zod/src/__tests__/contract.test.ts
+++ b/packages/zod/src/__tests__/contract.test.ts
@@ -1,9 +1,11 @@
-import { z as zod } from 'zod';
+import { z as zod_v3 } from 'zod/v3';
 import { describe, test, expect } from 'vitest';
 
 import { zodContract } from '../zod_contract';
 
-describe('zod/zodContract short', () => {
+describe('zod/zodContract short (zod v3)', () => {
+  const zod = zod_v3;
+
   test('interprets invalid response as error', () => {
     const contract = zodContract(zod.string());
 

--- a/packages/zod/src/__tests__/contract.test.ts
+++ b/packages/zod/src/__tests__/contract.test.ts
@@ -300,7 +300,9 @@ describe('zod/zodContract short (zod v4-mini)', () => {
         zod.object({
           x: zod.number(),
           y: zod.literal(true),
-          k: zod.set(zod.string(), { error: 'Invalid input: expected set of strings' }),
+          k: zod.set(zod.string(), {
+            error: 'Invalid input: expected set of strings',
+          }),
         }),
         zod.literal('Uhm?'),
         zod.literal(42),

--- a/packages/zod/src/__tests__/contract.test.ts
+++ b/packages/zod/src/__tests__/contract.test.ts
@@ -1,5 +1,6 @@
 import { z as zod_v3 } from 'zod/v3';
 import { z as zod_v4 } from 'zod/v4';
+import { z as zod_v4mini } from 'zod/v4-mini';
 import { describe, test, expect } from 'vitest';
 
 import { zodContract } from '../zod_contract';
@@ -195,6 +196,123 @@ describe('zod/zodContract short (zod v4)', () => {
           x: 456,
           y: false,
           k: new Set(),
+        },
+        'Answer is:',
+        '42',
+      ])
+    ).toMatchInlineSnapshot(`
+      [
+        "Invalid input: expected true, path: 0.y",
+        "Invalid input: expected set of strings, path: 0.k",
+        "Invalid input: expected "Uhm?", path: 1",
+        "Invalid input: expected 42, path: 2",
+      ]
+    `);
+  });
+
+  test('path from original zod error included in final message', () => {
+    const contract = zodContract(
+      zod.object({
+        x: zod.number(),
+        y: zod.object({
+          z: zod.string(),
+          k: zod.object({
+            j: zod.boolean(),
+          }),
+        }),
+      })
+    );
+
+    expect(
+      contract.getErrorMessages({
+        x: '42',
+        y: {
+          z: 123,
+          k: {
+            j: new Map(),
+          },
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      [
+        "Invalid input: expected number, received string, path: x",
+        "Invalid input: expected string, received number, path: y.z",
+        "Invalid input: expected boolean, received Map, path: y.k.j",
+      ]
+    `);
+  });
+});
+
+describe('zod/zodContract short (zod v4-mini)', () => {
+  const zod = zod_v4mini;
+
+  test('interprets invalid response as error', () => {
+    const contract = zodContract(zod.string());
+
+    expect(contract.getErrorMessages(2)).toMatchInlineSnapshot(`
+      [
+        "Invalid input: expected string, received number",
+      ]
+    `);
+  });
+
+  test('passes valid data', () => {
+    const contract = zodContract(zod.string());
+
+    expect(contract.getErrorMessages('foo')).toEqual([]);
+  });
+
+  test('isData passes for valid data', () => {
+    const contract = zodContract(
+      zod.object({
+        x: zod.number(),
+        y: zod.string(),
+      })
+    );
+
+    expect(
+      contract.isData({
+        x: 42,
+        y: 'answer',
+      })
+    ).toEqual(true);
+  });
+
+  test('isData does not pass for invalid data', () => {
+    const contract = zodContract(
+      zod.object({
+        x: zod.number(),
+        y: zod.string(),
+      })
+    );
+
+    expect(
+      contract.isData({
+        42: 'x',
+        answer: 'y',
+      })
+    ).toEqual(false);
+  });
+
+  test('interprets complex invalid response as error', () => {
+    const contract = zodContract(
+      zod.tuple([
+        zod.object({
+          x: zod.number(),
+          y: zod.literal(true),
+          k: zod.set(zod.string(), { error: 'Invalid input: expected set of strings' }),
+        }),
+        zod.literal('Uhm?'),
+        zod.literal(42),
+      ])
+    );
+
+    expect(
+      contract.getErrorMessages([
+        {
+          x: 456,
+          y: false,
+          k: new Map(),
         },
         'Answer is:',
         '42',

--- a/packages/zod/src/zod_contract.ts
+++ b/packages/zod/src/zod_contract.ts
@@ -1,16 +1,17 @@
 import { type ZodType as ZodTypeV3, type TypeOf as TypeOfV3 } from 'zod/v3';
-import { type $ZodType as ZodTypeV4, type output as TypeOfV4, safeParse } from 'zod/v4/core';
+import {
+  type $ZodType as ZodTypeV4,
+  type output as TypeOfV4,
+  safeParse,
+} from 'zod/v4/core';
 import { type Contract } from '@farfetched/core';
 
-type ZodAnyType =
-  | ZodTypeV3
-  | ZodTypeV4;
-type Output<T extends ZodAnyType> =
-  T extends ZodTypeV4
-    ? TypeOfV4<T>
-    : T extends ZodTypeV3
-      ? TypeOfV3<T>
-      : never;
+type ZodAnyType = ZodTypeV3 | ZodTypeV4;
+type Output<T extends ZodAnyType> = T extends ZodTypeV4
+  ? TypeOfV4<T>
+  : T extends ZodTypeV3
+    ? TypeOfV3<T>
+    : never;
 
 /**
  * Transforms Zod contracts for `data` to internal Contract.
@@ -22,16 +23,15 @@ function zodContract<T extends ZodAnyType>(
   data: T
 ): Contract<unknown, Output<T>> {
   function isData(prepared: unknown): prepared is Output<T> {
-    if ("_zod" in data) return safeParse(data, prepared).success;
+    if ('_zod' in data) return safeParse(data, prepared).success;
     return data.safeParse(prepared).success;
   }
 
   return {
     isData,
     getErrorMessages(raw) {
-      const validation = ("_zod" in data)
-        ? safeParse(data, raw)
-        : data.safeParse(raw);
+      const validation =
+        '_zod' in data ? safeParse(data, raw) : data.safeParse(raw);
       if (validation.success) {
         return [];
       }

--- a/packages/zod/src/zod_contract.ts
+++ b/packages/zod/src/zod_contract.ts
@@ -13,7 +13,7 @@ type Output<T extends ZodAnyType> = T extends ZodTypeV4
     ? TypeOfV3<T>
     : never;
 function isZodV4(schema: unknown): schema is ZodTypeV4 {
-  return !!schema && typeof schema === "object" && "_zod" in schema;
+  return !!schema && typeof schema === 'object' && '_zod' in schema;
 }
 
 /**
@@ -33,8 +33,9 @@ function zodContract<T extends ZodAnyType>(
   return {
     isData,
     getErrorMessages(raw) {
-      const validation =
-        isZodV4(data) ? safeParse(data, raw) : data.safeParse(raw);
+      const validation = isZodV4(data)
+        ? safeParse(data, raw)
+        : data.safeParse(raw);
       if (validation.success) {
         return [];
       }

--- a/packages/zod/src/zod_contract.ts
+++ b/packages/zod/src/zod_contract.ts
@@ -1,4 +1,5 @@
-import { type ZodType as ZodTypeV3, type TypeOf as TypeOfV3 } from 'zod/v3';
+import { type ZodType as ZodTypeV3 } from 'zod/v3';
+import { type $ZodType as ZodTypeV4, safeParse } from 'zod/v4/core';
 import { type Contract } from '@farfetched/core';
 
 /**
@@ -7,17 +8,20 @@ import { type Contract } from '@farfetched/core';
  *
  * @param {ZodTypeV3} data Zod Contract for valid data
  */
-function zodContract<T extends ZodTypeV3<any, any, any>>(
-  data: T
-): Contract<unknown, TypeOfV3<T>> {
+function zodContract<T>(
+  data: ZodTypeV3<T> | ZodTypeV4<T>
+): Contract<unknown, T> {
   function isData(prepared: unknown): prepared is T {
+    if ("_zod" in data) return safeParse(data, prepared).success;
     return data.safeParse(prepared).success;
   }
 
   return {
     isData,
     getErrorMessages(raw) {
-      const validation = data.safeParse(raw);
+      const validation = ("_zod" in data)
+        ? safeParse(data, raw)
+        : data.safeParse(raw);
       if (validation.success) {
         return [];
       }

--- a/packages/zod/src/zod_contract.ts
+++ b/packages/zod/src/zod_contract.ts
@@ -1,15 +1,15 @@
-import { type ZodType, type TypeOf } from 'zod/v3';
+import { type ZodType as ZodTypeV3, type TypeOf as TypeOfV3 } from 'zod/v3';
 import { type Contract } from '@farfetched/core';
 
 /**
  * Transforms Zod contracts for `data` to internal Contract.
  * Any response which does not conform to `data` will be treated as error.
  *
- * @param {ZodType} data Zod Contract for valid data
+ * @param {ZodTypeV3} data Zod Contract for valid data
  */
-function zodContract<T extends ZodType<any, any, any>>(
+function zodContract<T extends ZodTypeV3<any, any, any>>(
   data: T
-): Contract<unknown, TypeOf<T>> {
+): Contract<unknown, TypeOfV3<T>> {
   function isData(prepared: unknown): prepared is T {
     return data.safeParse(prepared).success;
   }

--- a/packages/zod/src/zod_contract.ts
+++ b/packages/zod/src/zod_contract.ts
@@ -22,7 +22,7 @@ function zodContract<T extends ZodTypeV3<any, any, any>>(
         return [];
       }
 
-      return validation.error.errors.map((e) => {
+      return validation.error.issues.map((e) => {
         const path = e.path.join('.');
         return path !== '' ? `${e.message}, path: ${path}` : e.message;
       });

--- a/packages/zod/src/zod_contract.ts
+++ b/packages/zod/src/zod_contract.ts
@@ -12,6 +12,9 @@ type Output<T extends ZodAnyType> = T extends ZodTypeV4
   : T extends ZodTypeV3
     ? TypeOfV3<T>
     : never;
+function isZodV4(schema: unknown): schema is ZodTypeV4 {
+  return !!schema && typeof schema === "object" && "_zod" in schema;
+}
 
 /**
  * Transforms Zod contracts for `data` to internal Contract.
@@ -23,7 +26,7 @@ function zodContract<T extends ZodAnyType>(
   data: T
 ): Contract<unknown, Output<T>> {
   function isData(prepared: unknown): prepared is Output<T> {
-    if ('_zod' in data) return safeParse(data, prepared).success;
+    if (isZodV4(data)) return safeParse(data, prepared).success;
     return data.safeParse(prepared).success;
   }
 
@@ -31,7 +34,7 @@ function zodContract<T extends ZodAnyType>(
     isData,
     getErrorMessages(raw) {
       const validation =
-        '_zod' in data ? safeParse(data, raw) : data.safeParse(raw);
+        isZodV4(data) ? safeParse(data, raw) : data.safeParse(raw);
       if (validation.success) {
         return [];
       }

--- a/packages/zod/src/zod_contract.ts
+++ b/packages/zod/src/zod_contract.ts
@@ -1,17 +1,27 @@
-import { type ZodType as ZodTypeV3 } from 'zod/v3';
-import { type $ZodType as ZodTypeV4, safeParse } from 'zod/v4/core';
+import { type ZodType as ZodTypeV3, type TypeOf as TypeOfV3 } from 'zod/v3';
+import { type $ZodType as ZodTypeV4, type output as TypeOfV4, safeParse } from 'zod/v4/core';
 import { type Contract } from '@farfetched/core';
+
+type ZodAnyType =
+  | ZodTypeV3
+  | ZodTypeV4;
+type Output<T extends ZodAnyType> =
+  T extends ZodTypeV4
+    ? TypeOfV4<T>
+    : T extends ZodTypeV3
+      ? TypeOfV3<T>
+      : never;
 
 /**
  * Transforms Zod contracts for `data` to internal Contract.
  * Any response which does not conform to `data` will be treated as error.
  *
- * @param {ZodTypeV3} data Zod Contract for valid data
+ * @param {ZodTypeV3 | ZodTypeV4} data Zod Contract for valid data
  */
-function zodContract<T>(
-  data: ZodTypeV3<T> | ZodTypeV4<T>
-): Contract<unknown, T> {
-  function isData(prepared: unknown): prepared is T {
+function zodContract<T extends ZodAnyType>(
+  data: T
+): Contract<unknown, Output<T>> {
+  function isData(prepared: unknown): prepared is Output<T> {
     if ("_zod" in data) return safeParse(data, prepared).success;
     return data.safeParse(prepared).success;
   }

--- a/packages/zod/src/zod_contract.ts
+++ b/packages/zod/src/zod_contract.ts
@@ -1,4 +1,4 @@
-import { type ZodType, type TypeOf } from 'zod';
+import { type ZodType, type TypeOf } from 'zod/v3';
 import { type Contract } from '@farfetched/core';
 
 /**

--- a/packages/zod/vite.config.ts
+++ b/packages/zod/vite.config.ts
@@ -20,7 +20,7 @@ export default {
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
-      external: ['zod'],
+      external: ['zod', 'zod/v3', 'zod/v4/core'],
     },
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,10 +258,10 @@ importers:
   packages/zod:
     specifiers:
       '@farfetched/core': workspace:*
-      zod: ^3.25.0
+      zod: ^3.25.67
     devDependencies:
       '@farfetched/core': link:../core
-      zod: 3.25.0
+      zod: 3.25.67
 
 packages:
 
@@ -7294,6 +7294,6 @@ packages:
     resolution: {integrity: sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==}
     dev: false
 
-  /zod/3.25.0:
-    resolution: {integrity: sha512-ficnZKUW0mlNivqeJkosTEkGbJ6NKCtSaOHGx5aXbtfeWMdRyzXLbAIn19my4C/KB7WPY/p9vlGPt+qpOp6c4Q==}
+  /zod/3.25.67:
+    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,10 +258,10 @@ importers:
   packages/zod:
     specifiers:
       '@farfetched/core': workspace:*
-      zod: ^3.19
+      zod: ^3.25.0
     devDependencies:
       '@farfetched/core': link:../core
-      zod: 3.19.1
+      zod: 3.25.0
 
 packages:
 
@@ -7292,3 +7292,8 @@ packages:
 
   /zod/3.19.1:
     resolution: {integrity: sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==}
+    dev: false
+
+  /zod/3.25.0:
+    resolution: {integrity: sha512-ficnZKUW0mlNivqeJkosTEkGbJ6NKCtSaOHGx5aXbtfeWMdRyzXLbAIn19my4C/KB7WPY/p9vlGPt+qpOp6c4Q==}
+    dev: true


### PR DESCRIPTION
Closes #542 

- feat: updated zod version for */zod contract package
- feat: added zod v4 support
- feat: added zod v4-mini support
- chore: added zod v4 tests (based on the existing v3 test)
- chore: added zod v4-mini tests (based on the existing v3 test; exclude "nonempty set" cause not supported in zod v4-mini yet)

Possible issues:
- failed test by timeout (not failed on timeout > 30_000ms (on my PC); `pnpm -r run test:run --test-timeout=30000`)
- failed prettier check on another packages
- failed size check:
```shell
packages/zod size$ size-limit
│                                                                                                                                                                                       
│   Package size limit has exceeded by 74 B
│   Size limit: 231 B
│   Size:       305 B gzipped
│                                                                                                                                                                                       
│   Try to reduce size or increase limit in "size-limit" section of package.json
└─ Failed in 159ms at E:\Web\forks\farfetched\packages\zod
\forks\farfetched\packages\zod:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @farfetched/zod@0.13.2 size: `size-limit
```